### PR TITLE
Use env name for conda environment.

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,1 @@
-conda
+env

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,8 +5,8 @@ MAKEDIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 # You can set these variables from the command line.
 SPHINXOPTS      =
-SPHINXBUILD     = [ -e conda/bin/activate ] && source conda/bin/activate; sphinx-build
-SPHINXAUTOBUILD = [ -e conda/bin/activate ] && source conda/bin/activate; sphinx-autobuild
+SPHINXBUILD     = [ -e env/bin/activate ] && source env/bin/activate; sphinx-build
+SPHINXAUTOBUILD = [ -e env/bin/activate ] && source env/bin/activate; sphinx-autobuild
 SPHINXPROJ      = SphinxVerilog
 SOURCEDIR       = .
 BUILDDIR        = _build
@@ -21,20 +21,20 @@ livehtml:
 .PHONY: help livehtml Makefile
 
 
-conda/Miniconda3-latest-Linux-x86_64.sh:
-	mkdir conda
-	wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O conda/Miniconda3-latest-Linux-x86_64.sh
-	chmod a+x conda/Miniconda3-latest-Linux-x86_64.sh
+env/Miniconda3-latest-Linux-x86_64.sh:
+	mkdir env
+	wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O env/Miniconda3-latest-Linux-x86_64.sh
+	chmod a+x env/Miniconda3-latest-Linux-x86_64.sh
 
-conda:
-	rm -rf conda
-	make conda/Miniconda3-latest-Linux-x86_64.sh
-	./conda/Miniconda3-latest-Linux-x86_64.sh -p $(PWD)/conda -b -f
-	source conda/bin/activate; conda config --system --add envs_dirs $(PWD)/conda/envs
-	source conda/bin/activate; conda config --system --add pkgs_dirs $(PWD)/conda/pkgs
-	source conda/bin/activate; conda env update --name base --file ../environment.yml
+env:
+	rm -rf env
+	make env/Miniconda3-latest-Linux-x86_64.sh
+	./env/Miniconda3-latest-Linux-x86_64.sh -p $(PWD)/env -b -f
+	source env/bin/activate; conda config --system --add envs_dirs $(PWD)/env/envs
+	source env/bin/activate; conda config --system --add pkgs_dirs $(PWD)/env/pkgs
+	source env/bin/activate; conda env update --name base --file ../environment.yml
 
-.PHONY: conda
+.PHONY: env
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'conda', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'env', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'default'


### PR DESCRIPTION
The name env can be used for virtualenv or conda.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>