### PR TITLE
Add -compat-int option to write_json for netlistsvg to work

### DIFF
--- a/sphinxcontrib_verilog_diagrams.py
+++ b/sphinxcontrib_verilog_diagrams.py
@@ -218,7 +218,7 @@ def diagram_netlistsvg(ipath, opath, module='top', flatten=False):
     run_yosys(
         src=ipath,
         cmd = """\
-prep -top {top} {flatten}; cd {top}; write_json {ojson}
+prep -top {top} {flatten}; cd {top}; write_json -compat-int {ojson}
 """.format(top=module, flatten=flatten, ojson=ojson).strip())
     assert path.exists(ojson), 'Output file {} was not created!'.format(ojson)
 


### PR DESCRIPTION
The JSON output by Yosys has changed in a way that stops netlistsvg from working. This patch fixes the problem by requesting Yosys to produce the output in compatibility mode.

See nturley/netlistsvg#87 for more detailed information.