### PR TITLE
Directive to include code without license header

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,14 +9,20 @@ diagrams from verilog code.
 
 The project repository is hosted on `GitHub <https://github.com/SymbiFlow/sphinxcontrib-verilog-diagrams>`_.
 
+Most of the time there will be a license header at the top of source code, 
+which we will never want to show in the documentation. 
+This extension provides the `.. no-license` RST directive which works exactly 
+like the `.. literalinclude` directive, but the `lines` option is overridden
+to only show the lines after the license header.
+
 Usage Examples
 ==============
 
 Single DFF
 ----------
 
-Verilog Code
-~~~~~~~~~~~~
+Verilog Code (without license header)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 RST Directive
 +++++++++++++
@@ -24,7 +30,7 @@ RST Directive
 .. code-block:: rst
    :linenos:
 
-   .. literalinclude:: verilog/dff.v
+   .. no-license:: verilog/dff.v
       :language: verilog
       :linenos:
       :caption: verilog/dff.v
@@ -32,7 +38,7 @@ RST Directive
 Result
 ++++++
 
-.. literalinclude:: verilog/dff.v
+.. no-license:: verilog/dff.v
    :language: verilog
    :linenos:
    :caption: verilog/dff.v

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,8 @@ This extension provides the `.. no-license` RST directive which works exactly
 like the `.. literalinclude` directive, but the `lines` option is overridden
 to only show the lines after the license header.
 
+The project repository is hosted on `GitHub <https://github.com/SymbiFlow/sphinxcontrib-verilog-diagrams>`_.
+
 Usage Examples
 ==============
 

--- a/sphinxcontrib_verilog_diagrams.py
+++ b/sphinxcontrib_verilog_diagrams.py
@@ -110,9 +110,13 @@ class NoLicenseInclude(LiteralInclude):
 
         rel_filename, filename = self.env.relfn2path(self.arguments[0])
         code = open(rel_filename, 'r').read().strip().split('\n')
+
         first_line = next(
-            (idx + 3 for idx, line in enumerate(code) if 'SPDX' in line), 1)
+            (idx for idx, line in enumerate(code) if 'SPDX' in line), 1)
+        if first_line > 1:
+            first_line += 3 if code[first_line][1] == '*' else 2
         last_line = len(code)
+
         self.options['lines'] = '{}-{}'.format(first_line, last_line)
 
         try:


### PR DESCRIPTION
This is implemented in the `no-license` directive, which has the exact same usage and options as `literalinclude`. Only difference is the `lines` options is set to start after the license header and to end at the last line of the file.

The end of the license header is detected by searching for the line that contains the SPDX identifier. Therefore this directive assumes that the license header contains the SPDX identifier.

I’m not sure how to name it :P. `no-license` sounds weird while `no-license-include` is so long. Running out of ideas.

Resolve https://github.com/SymbiFlow/python-symbiflow-v2x/issues/47

Signed-off-by: Daniel Lim Wee Soong <weesoong.lim@gmail.com>