### PR TITLE
docs: Add links between GitHub repo and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ sphinxcontrib-verilog-diagrams
 
 [![PyPI](https://img.shields.io/pypi/v/sphinx-verilog-diagrams.svg)](https://pypi.python.org/pypi/sphinx-verilog-diagrams)
 [![PyPI version](https://img.shields.io/pypi/pyversions/sphinx-verilog-diagrams.svg)](https://pypi.python.org/pypi/sphinx-verilog-diagrams)
-[![Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://mithro.github.io/sphinx-verilog-diagrams)
+[![Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://sphinxcontrib-verilog-diagrams.readthedocs.io/en/latest/)
 [![Build Status](https://travis-ci.org/mithro/sphinx-verilog-diagrams.svg?branch=master)](https://travis-ci.org/mithro/sphinx-verilog-diagrams)
 [![codecov](https://codecov.io/gh/mithro/sphinx-verilog-diagrams/branch/master/graph/badge.svg)](https://codecov.io/gh/mithro/sphinx-verilog-diagrams)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,8 @@ nice documentation from Verilog files.
 You use the `.. verilog-diagram` RST directive to generate various styles of
 diagrams from verilog code.
 
+The project repository is hosted on `GitHub <https://github.com/SymbiFlow/sphinxcontrib-verilog-diagrams>`_.
+
 Usage Examples
 ==============
 


### PR DESCRIPTION
As stated in the title,

- Fix the broken link from README.md to the docs
- Add a link from the docs to the GitHub repo

Close #15 

Signed-off-by: Daniel Lim Wee Soong <weesoong.lim@gmail.com>