### PR TITLE
Use yowasp_yosys instead of system-installed yosys

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,16 @@ Required
 .. |yosys| replace:: ``yosys``
 .. _yosys: https://github.com/YosysHQ/yosys
 
+By default, `verilog-diagram` uses the `yowasp-yosys` package provided in PyPI. It can be installed by running `pip install -r requirements.txt`.
+However, you could also use the `yosys` that is installed on your system, by adding the following line in `setup(app)` inside conf.py.
+
+.. code-block:: py
+   def setup(app):
+      ...
+      VerilogDiagram.use_yowasp = False
+      ...
+
+
 Optional
 ~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,7 @@ By default, `verilog-diagram` uses the `yowasp-yosys` package provided in PyPI. 
 However, you could also use the `yosys` that is installed on your system, by adding the following line in `setup(app)` inside conf.py.
 
 .. code-block:: py
+
    def setup(app):
       ...
       VerilogDiagram.use_yowasp = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ import re
 #
 import os
 import sys
+from sphinxcontrib_verilog_diagrams import VerilogDiagram
 sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
@@ -251,3 +252,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}
+
+def setup(app):
+    # VerilogDiagram.use_yowasp = False
+    pass

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,6 @@ dependencies:
 - pip
 - python=3.7
 - sphinx
-- yosys
 - pip:          # Packages installed from PyPI
   - -r file:requirements.txt
   - -r file:docs/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ setuptools
 docutils
 sphinx
 
+yowasp-yosys>=0.9.post4547.dev9
+
 # Needed to upload to PyPi
 twine

--- a/sphinxcontrib_verilog_diagrams/__init__.py
+++ b/sphinxcontrib_verilog_diagrams/__init__.py
@@ -43,8 +43,6 @@ from sphinx.util import logging
 from sphinx.util.i18n import search_image_for_language
 from sphinx.util.osutil import ensuredir, ENOENT, EPIPE, EINVAL
 
-import yowasp_yosys
-
 if False:
     # For type annotation
     from typing import Any, Dict, List, Tuple  # NOQA
@@ -150,6 +148,8 @@ class VerilogDiagram(Directive):
 
     final_argument_whitespace = False
 
+    use_yowasp = True
+
     option_spec = {
         'type': str,
         'module': str,
@@ -210,9 +210,14 @@ class VerilogDiagram(Directive):
 
 
 def run_yosys(src, cmd):
-    ycmd = ["-q", "-p", cmd, src]
     print("Running yosys: yosys -q -p", "'{}'".format(cmd), src)
-    yowasp_yosys.run_yosys(ycmd)
+    if VerilogDiagram.use_yowasp:
+        import yowasp_yosys
+        ycmd = ["-q", "-p", "{}".format(cmd), src]
+        yowasp_yosys.run_yosys(ycmd)
+    else:
+        ycmd = "yosys -p '{cmd}' {src}".format(src=src, cmd=cmd)
+        subprocess.check_output(ycmd, shell=True)
 
 
 def diagram_yosys(ipath, opath, module='top', flatten=False):
@@ -233,10 +238,12 @@ def diagram_yosys(ipath, opath, module='top', flatten=False):
 prep -top {top} {flatten}; cd {top}; show -format {fmt} -prefix {oprefix}
 """.format(top=module, flatten=flatten, fmt=oext, oprefix=oprefix).strip(),
     )
-    # somehow yowasp_yosys fails to execute `dot` to convert the dot file to svg,
-    # perhaps a limitation with wasm
-    svgdata = subprocess.check_output(["dot", "-Tsvg", "{}.dot".format(oprefix)])
-    open("{}.svg".format(oprefix), "wb").write(svgdata)
+
+    if VerilogDiagram.use_yowasp:
+        # somehow yowasp_yosys fails to execute `dot` to convert the dot file to svg,
+        # which works on native yosys, perhaps a limitation with wasm
+        svgdata = subprocess.check_output(["dot", "-Tsvg", "{}.dot".format(oprefix)])
+        open("{}.svg".format(oprefix), "wb").write(svgdata)
 
     assert path.exists(opath), 'Output file {} was not created!'.format(oopath)
     print('Output file created: {}'.format(opath))

--- a/sphinxcontrib_verilog_diagrams/__init__.py
+++ b/sphinxcontrib_verilog_diagrams/__init__.py
@@ -43,6 +43,8 @@ from sphinx.util import logging
 from sphinx.util.i18n import search_image_for_language
 from sphinx.util.osutil import ensuredir, ENOENT, EPIPE, EINVAL
 
+import yowasp_yosys
+
 if False:
     # For type annotation
     from typing import Any, Dict, List, Tuple  # NOQA
@@ -208,9 +210,9 @@ class VerilogDiagram(Directive):
 
 
 def run_yosys(src, cmd):
-    ycmd = "yosys -p '{cmd}' {src}".format(src=src, cmd=cmd)
-    print("Running yosys:", ycmd)
-    subprocess.check_output(ycmd, shell=True)
+    ycmd = ["-q", "-p", cmd, src]
+    print("Running yosys: yosys -q -p", "'{}'".format(cmd), src)
+    yowasp_yosys.run_yosys(ycmd)
 
 
 def diagram_yosys(ipath, opath, module='top', flatten=False):
@@ -231,6 +233,10 @@ def diagram_yosys(ipath, opath, module='top', flatten=False):
 prep -top {top} {flatten}; cd {top}; show -format {fmt} -prefix {oprefix}
 """.format(top=module, flatten=flatten, fmt=oext, oprefix=oprefix).strip(),
     )
+    # somehow yowasp_yosys fails to execute `dot` to convert the dot file to svg,
+    # perhaps a limitation with wasm
+    svgdata = subprocess.check_output(["dot", "-Tsvg", "{}.dot".format(oprefix)])
+    open("{}.svg".format(oprefix), "wb").write(svgdata)
 
     assert path.exists(opath), 'Output file {} was not created!'.format(oopath)
     print('Output file created: {}'.format(opath))
@@ -268,7 +274,7 @@ def diagram_netlistsvg(ipath, opath, module='top', flatten=False):
     run_yosys(
         src=ipath,
         cmd = """\
-prep -top {top} {flatten}; cd {top}; write_json {ojson}
+prep -top {top} {flatten}; cd {top}; write_json -compat-int {ojson}
 """.format(top=module, flatten=flatten, ojson=ojson).strip())
     assert path.exists(ojson), 'Output file {} was not created!'.format(ojson)
 


### PR DESCRIPTION
Following the discussion in #40, change to use the wasm-bundled version of yosys as in [yowasp_yosys](https://github.com/YoWASP/yosys) instead of the system-installed yosys (symbiflow projects use conda to install it, but this might not be the case for other users).

One benefit of this is that it allows us to control the version of yosys used by the user. This is important because there might be breaking changes in yosys, such as #13, and it wouldn't be ideal to cater for multiple versions of yosys.

One small downside is this takes about twice the duration compared to native yosys but I don't think this really matters.

Signed-off-by: Daniel Lim Wee Soong <weesoong.lim@gmail.com>