### PR TITLE
Use correct path in no-license

### DIFF
--- a/sphinxcontrib_verilog_diagrams/__init__.py
+++ b/sphinxcontrib_verilog_diagrams/__init__.py
@@ -116,7 +116,7 @@ class NoLicenseInclude(LiteralInclude):
         # type: () -> List[nodes.Node]
 
         rel_filename, filename = self.env.relfn2path(self.arguments[0])
-        code = open(rel_filename, 'r').read().strip().split('\n')
+        code = open(filename, 'r').read().strip().split('\n')
 
         first_line = next(
             (idx for idx, line in enumerate(code) if 'SPDX' in line), 1)


### PR DESCRIPTION
### Current state

* `verilog-diagram` directive and `LiteralInclude` (`NoLicenseInclude`'s parent class) resolve source file path relative to the .rst file's directory
* `no-license` uses path relative to CWD

When .rst files are in different directory than Makefile, things stop to work:
* `no-license` and `verilog-diagrams` used in the same project with the same source file path will cause build error (see snippet below)
* `no-license` won't work at all, no matter what path is provided - line offset (for skipping license comment) is calculated for a file relative to CWD, while the code to be displayed is loaded from a path relative to .rst file's directory.

The PR fixes this - paths are always relative to .rst file directory.

### How to reproduce

```
# CWD = sphinxcontrib-verilog-diagrams toplevel directory
$ cd docs
$ mkdir source
$ mv _static conf.py index.rst requirements.txt verilog source/
$ make SOURCEDIR=./source html

(...)
Exception occurred:
  File "/sphinxcontrib-verilog-diagrams/sphinxcontrib_verilog_diagrams/__init__.py", line 120, in run
    code = open(rel_filename, 'r').read().strip().split('\n')
FileNotFoundError: [Errno 2] No such file or directory: 'verilog/dff.v'
(...)

# Maybe source paths are relative to current working directory?
$ mv source/verilog ./

(...)
Exception occurred:
  File "/sphinxcontrib-verilog-diagrams/sphinxcontrib_verilog_diagrams/__init__.py", line 218, in diagram_yosys
    assert path.exists(ipath), 'Input file missing: {}'.format(ipath)
AssertionError: Input file missing: /sphinxcontrib-verilog-diagrams/docs/source/verilog/dff.v
(...)

$ mv verilog source/
```
