### PR TITLE
Fix Travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ stages:
     - name:
         - Test
         - Build
+        - Deploy
 
 jobs:
     - stage: Tests
@@ -26,14 +27,15 @@ jobs:
       script:
         - make build
 
-before_deploy:
-    - make clean
-    - make sphinxcontrib_verilog_diagrams/version.py
-    - sudo ln -sf /usr/bin/python3 /usr/bin/python
-
-deploy:
-  provider: pypi
-  username: __token__
-  distributions: sdist bdist_wheel
-  skip_existing: true
-  edge: true # opt in to dpl v2
+    - stage: Deploy
+      name: "PyPI"
+      before_deploy:
+        - make clean
+        - make sphinxcontrib_verilog_diagrams/version.py
+        - sudo ln -sf /usr/bin/python3 /usr/bin/python
+      deploy:
+        provider: pypi
+        username: __token__
+        distributions: sdist bdist_wheel
+        skip_existing: true
+        edge: true # opt in to dpl v2


### PR DESCRIPTION
After merging the #52 the `master` branch failed on the deployment step. 

This was caused by the fact that the directory path was not reset correctly to the repository root. Moving the deployment to the next step should resolve the issue. I checked it on my local fork.
